### PR TITLE
关闭滑动状态下会出现点击子控件被拦截情况

### DIFF
--- a/swipemenulib/src/main/java/com/mcxtzhang/swipemenulib/SwipeMenuLayout.java
+++ b/swipemenulib/src/main/java/com/mcxtzhang/swipemenulib/SwipeMenuLayout.java
@@ -479,7 +479,8 @@ public class SwipeMenuLayout extends ViewGroup {
             //IOS模式开启，且当前有菜单的View，且不是自己的 拦截点击事件给子View
             return true;
         }
-
+        // TODO: 2016/12/7 0007  暂时修改 临时解决滑动关闭状态下子控件点击事件会被屏蔽的bug
+        mFirstP.set(ev.getRawX(), ev.getRawY());
         return super.onInterceptTouchEvent(ev);
     }
 

--- a/swipemenulib/src/main/java/com/mcxtzhang/swipemenulib/SwipeMenuLayout.java
+++ b/swipemenulib/src/main/java/com/mcxtzhang/swipemenulib/SwipeMenuLayout.java
@@ -430,57 +430,61 @@ public class SwipeMenuLayout extends ViewGroup {
 
     @Override
     public boolean onInterceptTouchEvent(MotionEvent ev) {
-        switch (ev.getAction()) {
-            //add by zhangxutong 2016 11 04 begin :
-            // fix 长按事件和侧滑的冲突。
-            case MotionEvent.ACTION_MOVE:
-                //屏蔽滑动时的事件
-                if (Math.abs(ev.getRawX() - mFirstP.x) > mScaleTouchSlop) {
-                    return true;
-                }
-                break;
-            //add by zhangxutong 2016 11 04 end
-            case MotionEvent.ACTION_UP:
-                //为了在侧滑时，屏蔽子View的点击事件
-                if (isLeftSwipe) {
-                    if (getScrollX() > mScaleTouchSlop) {
-                        //add by 2016 09 10 解决一个智障问题~ 居然不给点击侧滑菜单 我跪着谢罪
-                        //这里判断落点在内容区域屏蔽点击，内容区域外，允许传递事件继续向下的的。。。
-                        if (ev.getX() < getWidth() - getScrollX()) {
-                            //2016 10 22 add , 仿QQ，侧滑菜单展开时，点击内容区域，关闭侧滑菜单。
-                            if (isUnMoved) {
-                                smoothClose();
+        // TODO: 2016/12/7 0007  暂时修改 临时解决滑动关闭状态下子控件点击事件会被屏蔽的bug
+        if(isSwipeEnable) {
+            switch (ev.getAction()) {
+                //add by zhangxutong 2016 11 04 begin :
+                // fix 长按事件和侧滑的冲突。
+                case MotionEvent.ACTION_MOVE:
+                    //屏蔽滑动时的事件
+                    if (Math.abs(ev.getRawX() - mFirstP.x) > mScaleTouchSlop) {
+                        return true;
+                    }
+                    break;
+                //add by zhangxutong 2016 11 04 end
+                case MotionEvent.ACTION_UP:
+                    //为了在侧滑时，屏蔽子View的点击事件
+                    if (isLeftSwipe) {
+                        if (getScrollX() > mScaleTouchSlop) {
+                            //add by 2016 09 10 解决一个智障问题~ 居然不给点击侧滑菜单 我跪着谢罪
+                            //这里判断落点在内容区域屏蔽点击，内容区域外，允许传递事件继续向下的的。。。
+                            if (ev.getX() < getWidth() - getScrollX()) {
+                                //2016 10 22 add , 仿QQ，侧滑菜单展开时，点击内容区域，关闭侧滑菜单。
+                                if (isUnMoved) {
+                                    smoothClose();
+                                }
+                                return true;//true表示拦截
                             }
-                            return true;//true表示拦截
+                        }
+                    } else {
+                        if (-getScrollX() > mScaleTouchSlop) {
+                            if (ev.getX() > -getScrollX()) {//点击范围在菜单外 屏蔽
+                                //2016 10 22 add , 仿QQ，侧滑菜单展开时，点击内容区域，关闭侧滑菜单。
+                                if (isUnMoved) {
+                                    smoothClose();
+                                }
+                                return true;
+                            }
                         }
                     }
-                } else {
-                    if (-getScrollX() > mScaleTouchSlop) {
-                        if (ev.getX() > -getScrollX()) {//点击范围在菜单外 屏蔽
-                            //2016 10 22 add , 仿QQ，侧滑菜单展开时，点击内容区域，关闭侧滑菜单。
-                            if (isUnMoved) {
-                                smoothClose();
-                            }
-                            return true;
-                        }
+                    //add by zhangxutong 2016 11 03 begin:
+                    // 判断手指起始落点，如果距离属于滑动了，就屏蔽一切点击事件。
+                    Log.e("View",isUserSwiped + "" + "out");
+                    if (isUserSwiped) {
+                        Log.e("View",isUserSwiped + "" + "in");
+                        return true;
                     }
-                }
-                //add by zhangxutong 2016 11 03 begin:
-                // 判断手指起始落点，如果距离属于滑动了，就屏蔽一切点击事件。
-                if (isUserSwiped) {
-                    return true;
-                }
-                //add by zhangxutong 2016 11 03 end
+                    //add by zhangxutong 2016 11 03 end
 
-                break;
+                    break;
+            }
         }
         //模仿IOS 点击其他区域关闭：
         if (iosInterceptFlag) {
             //IOS模式开启，且当前有菜单的View，且不是自己的 拦截点击事件给子View
             return true;
         }
-        // TODO: 2016/12/7 0007  暂时修改 临时解决滑动关闭状态下子控件点击事件会被屏蔽的bug
-        mFirstP.set(ev.getRawX(), ev.getRawY());
+        
         return super.onInterceptTouchEvent(ev);
     }
 

--- a/swipemenulib/src/main/java/com/mcxtzhang/swipemenulib/SwipeMenuLayout.java
+++ b/swipemenulib/src/main/java/com/mcxtzhang/swipemenulib/SwipeMenuLayout.java
@@ -430,7 +430,7 @@ public class SwipeMenuLayout extends ViewGroup {
 
     @Override
     public boolean onInterceptTouchEvent(MotionEvent ev) {
-        // TODO: 2016/12/7 0007  暂时修改 临时解决滑动关闭状态下子控件点击事件会被屏蔽的bug
+        //add by SparkChenZ 2016/12/7 0007  暂时修改 临时解决滑动关闭状态下子控件点击事件会被屏蔽的bug
         if(isSwipeEnable) {
             switch (ev.getAction()) {
                 //add by zhangxutong 2016 11 04 begin :


### PR DESCRIPTION
使用过程中发现了在关闭滑动的情况下，会出现view点击事件难以响应问题，但是在开启滑动情况下却是正常的，很快的时间去debug了源码，发现是判断是否用户滑动造成判断出现问题，时间不充裕，临时添加了判断更改，解决关闭滑动情况下子控件屏蔽问题